### PR TITLE
install the unixodbc driver

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,6 +4,11 @@ BUILD_DIR = $1
 CACHE_DIR = $2
 ENV_DIR = $3
 
+# install the unixodbc driver first as it has some files that
+# are needed for snowflake odbc
+curl http://www.unixodbc.org/unixODBC-2.3.4.tar.gz | tar xvz
+./unixODBC-2.3.4/install-sh
+
 tar -xzf support/snowflake_linux_x8664_odbc.tgz --directory $BUILD_DIR
 cd ./snowflake_odbc
 ./unixodbc_setup.sh


### PR DESCRIPTION
install the unixodbc driver first so that we can get the header files needed for installing snowflake odbc

Merging w/o a code review because we're still bootstrapping the buildpack.