### PR TITLE
wrap some quotes around BUILD_DIR in order to see if it has whitespace

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ BUILD_DIR = $1
 CACHE_DIR = $2
 ENV_DIR = $3
 
-echo 'Validating the BUILD_DIR'
+echo 'Validating the \"BUILD_DIR\"'
 if [$BUILD_DIR == ""]; then
     echo "Empty BUILD_DIR.  Using $PWD"
 fi


### PR DESCRIPTION
More debugging code to see why the compile is failing when it tries to decompress snowflake odbc.